### PR TITLE
Add Inspect functionality to analyze ETW trace files and return information about processes

### DIFF
--- a/src/Ultra.Core/CommandInputsOutputs.cs
+++ b/src/Ultra.Core/CommandInputsOutputs.cs
@@ -1,0 +1,39 @@
+﻿using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Ultra.Core
+{
+    internal readonly struct InspectProcessInfo(string name, int pid, string commandLine, int events)
+    {
+        public string Name => name;
+        public int Pid => pid;
+        public string CommandLine => commandLine;
+        public int Events => events;
+    }
+
+    internal class InspectOutput(string operatingSystem, int totalEvents, TimeSpan duration)
+    {
+        public string OperatingSystem => operatingSystem;
+        public int TotalEvents => totalEvents;
+        public TimeSpan Duration => duration;
+        public List<InspectProcessInfo> Processes { get; } = [ ];
+    }
+
+    [JsonSerializable(typeof(InspectOutput))]
+    internal partial class CommandInputsOutputsJsonSerializerContext : JsonSerializerContext
+    {
+        static CommandInputsOutputsJsonSerializerContext()
+        {
+            // Replace context with new options which are more human-friendly for text output
+            var options = new JsonSerializerOptions()
+            {
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                WriteIndented = true
+            };
+
+            var context = new CommandInputsOutputsJsonSerializerContext(options);
+            Default = context;
+        }
+    }
+}

--- a/src/Ultra.Core/EtwConverterToFirefox.cs
+++ b/src/Ultra.Core/EtwConverterToFirefox.cs
@@ -28,10 +28,11 @@ public sealed class EtwConverterToFirefox : IDisposable
     private readonly Dictionary<MethodIndex, int> _mapMethodIndexToFirefox;
     private readonly Dictionary<string, int> _mapStringToFirefox;
     private readonly SymbolReader _symbolReader;
-    private readonly ETWTraceEventSource _etl;
+    private readonly TraceEventDispatcher _etl;
     private readonly TraceLog _traceLog;
     private ModuleFileIndex _clrJitModuleIndex = ModuleFileIndex.Invalid;
     private ModuleFileIndex _coreClrModuleIndex = ModuleFileIndex.Invalid;
+    private ModuleFileIndex _clrModuleIndex = ModuleFileIndex.Invalid; // netfw clr
     private int _profileThreadIndex;
     private readonly EtwUltraProfilerOptions _options;
     private readonly FirefoxProfiler.Profile _profile;
@@ -73,8 +74,9 @@ public sealed class EtwConverterToFirefox : IDisposable
 
     private EtwConverterToFirefox(string traceFilePath, EtwUltraProfilerOptions options)
     {
-        _etl = new ETWTraceEventSource(traceFilePath);
-        _traceLog = TraceLog.OpenOrConvert(traceFilePath);
+        _etl = TraceLogEventSource.GetDispatcherFromFileName(traceFilePath);
+        var traceLogFilePath = TraceLog.CreateFromEventTraceLogFile(_etl, Path.ChangeExtension(traceFilePath, ".etlx"));
+        _traceLog = TraceLog.OpenOrConvert(traceLogFilePath);
 
         var symbolPath = options.GetCachedSymbolPath();
         var symbolPathText = symbolPath.ToString();
@@ -144,7 +146,7 @@ public sealed class EtwConverterToFirefox : IDisposable
             inspectProfile.Processes.Add(processInfo);
         }
 
-        inspectProfile.Processes.Sort((x, y) => y.Events - x.Events);
+        inspectProfile.Processes.Sort((x, y) => x.Events.CompareTo(y.Events));
         return JsonSerializer.Serialize(inspectProfile, CommandInputsOutputsJsonSerializerContext.Default.InspectOutput);
     }
 
@@ -174,6 +176,11 @@ public sealed class EtwConverterToFirefox : IDisposable
         foreach (var processId in processIds)
         {
             var process = _traceLog.Processes.LastProcessWithID(processId);
+
+            if (process is not {})
+            {
+                throw new InvalidOperationException($"Process with ID {processId} not found in the ETL file.");
+            }
 
             ConvertProcess(process);
         }
@@ -248,6 +255,8 @@ public sealed class EtwConverterToFirefox : IDisposable
             _mapCodeAddressIndexToMethodIndexFirefox.Clear();
 
             Stack<(double, GCSuspendExecutionEngineEvent)> gcSuspendEEEvents = new();
+            Stack<(double, ContentionStartTraceData)> contentionEvents = new();
+
             Stack<double> gcRestartEEEvents = new();
             Stack<(double, GCEvent)> gcStartStopEvents = new();
 
@@ -356,7 +365,7 @@ public sealed class EtwConverterToFirefox : IDisposable
                             markers.Category.Add(CategoryGc);
                             markers.Phase.Add(FirefoxProfiler.MarkerPhase.Instance);
                             markers.ThreadId.Add(_profileThreadIndex);
-                            markers.Name.Add(GetOrCreateString($"GCHeapStats", profileThread));
+                            markers.Name.Add(GetOrCreateString("GCHeapStats", profileThread));
 
                             var heapStatEvent = new GCHeapStatsEvent
                             {
@@ -432,7 +441,7 @@ public sealed class EtwConverterToFirefox : IDisposable
                                 markers.Category.Add(CategoryGc);
                                 markers.Phase.Add(FirefoxProfiler.MarkerPhase.Interval);
                                 markers.ThreadId.Add(_profileThreadIndex);
-                                markers.Name.Add(GetOrCreateString($"GC Event", profileThread));
+                                markers.Name.Add(GetOrCreateString("GC Event", profileThread));
                                 markers.Data.Add(gcEvent);
                                 markers.Length++;
                             }
@@ -456,7 +465,7 @@ public sealed class EtwConverterToFirefox : IDisposable
                                 markers.Category.Add(CategoryGc);
                                 markers.Phase.Add(FirefoxProfiler.MarkerPhase.Interval);
                                 markers.ThreadId.Add(_profileThreadIndex);
-                                markers.Name.Add(GetOrCreateString($"GC Suspend EE", profileThread));
+                                markers.Name.Add(GetOrCreateString("GC Suspend EE", profileThread));
                                 markers.Data.Add(gcSuspendEEEvent);
                                 markers.Length++;
                             }
@@ -474,8 +483,42 @@ public sealed class EtwConverterToFirefox : IDisposable
                                 markers.Category.Add(CategoryGc);
                                 markers.Phase.Add(FirefoxProfiler.MarkerPhase.Interval);
                                 markers.ThreadId.Add(_profileThreadIndex);
-                                markers.Name.Add(GetOrCreateString($"GC Restart EE", profileThread));
+                                markers.Name.Add(GetOrCreateString("GC Restart EE", profileThread));
                                 markers.Data.Add(null);
+                                markers.Length++;
+                            }
+                            else if (evt is ContentionStartTraceData contentionStartTraceData)
+                            {
+                                contentionEvents.Push((evt.TimeStampRelativeMSec, contentionStartTraceData));
+                            }
+                            else if (evt is ContentionStopTraceData contentionStopTraceData && contentionEvents.Count > 0)
+                            {
+                                var (contentionStartTime, contentionStart) = contentionEvents.Pop();
+                                markers.StartTime.Add(contentionStartTime);
+                                markers.EndTime.Add(evt.TimeStampRelativeMSec);
+                                markers.Category.Add(CategoryClr);
+                                markers.Phase.Add(FirefoxProfiler.MarkerPhase.Interval);
+                                markers.ThreadId.Add(_profileThreadIndex);
+                                markers.Name.Add(GetOrCreateString("Contention", profileThread));
+
+                                markers.Data.Add(null);
+                                markers.Length++;
+                            }
+                            else if (evt is FinalizeObjectTraceData finalizeObjectTraceData)
+                            {
+                                markers.StartTime.Add(evt.TimeStampRelativeMSec);
+                                markers.EndTime.Add(evt.TimeStampRelativeMSec);
+                                markers.Category.Add(CategoryClr);
+                                markers.Phase.Add(FirefoxProfiler.MarkerPhase.Instance);
+                                markers.ThreadId.Add(_profileThreadIndex);
+                                markers.Name.Add(GetOrCreateString("FinalizeObject", profileThread));
+
+                                var finalizeEvent = new FinalizeObjectEvent
+                                {
+                                    TypeName = finalizeObjectTraceData.TypeName,
+                                };
+
+                                markers.Data.Add(finalizeEvent);
                                 markers.Length++;
                             }
                         }
@@ -601,6 +644,7 @@ public sealed class EtwConverterToFirefox : IDisposable
         _setManagedModules.Clear();
         _clrJitModuleIndex = ModuleFileIndex.Invalid;
         _coreClrModuleIndex = ModuleFileIndex.Invalid;
+        _clrModuleIndex = ModuleFileIndex.Invalid;
 
         var allModules = process.LoadedModules.ToList();
         for (var i = 0; i < allModules.Count; i++)
@@ -622,7 +666,7 @@ public sealed class EtwConverterToFirefox : IDisposable
                     Arch = "x64" // TODO
                 };
 
-                _traceLog!.CodeAddresses.LookupSymbolsForModule(_symbolReader, module.ModuleFile);
+                _traceLog.CodeAddresses.LookupSymbolsForModule(_symbolReader, module.ModuleFile);
 
                 _mapModuleFileIndexToFirefox.Add(module.ModuleFile.ModuleFileIndex, _profile.Libs.Count);
                 _profile.Libs.Add(lib);
@@ -637,18 +681,27 @@ public sealed class EtwConverterToFirefox : IDisposable
             {
                 _coreClrModuleIndex = module.ModuleFile.ModuleFileIndex;
             }
+            else if (fileName.Equals("clr.dll", StringComparison.OrdinalIgnoreCase))
+            {
+                _clrModuleIndex = module.ModuleFile.ModuleFileIndex;
+            }
 
             if (module is TraceManagedModule managedModule)
             {
                 _setManagedModules.Add(managedModule.ModuleFile.ModuleFileIndex);
 
-                foreach (var otherModule in allModules.Where(x => x is not TraceManagedModule))
-                {
-                    if (string.Equals(managedModule.FilePath, otherModule.FilePath, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _setManagedModules.Add(otherModule.ModuleFile.ModuleFileIndex);
-                    }
-                }
+                // foreach (var otherModule in unmanagedModules)
+                // {
+                //     if (string.Equals(managedModule.FilePath, otherModule.FilePath, StringComparison.OrdinalIgnoreCase))
+                //     {
+                //         _setManagedModules.Add(otherModule.ModuleFile.ModuleFileIndex);
+                //     }
+                // }
+            }
+
+            if (module.ModuleFile is { ManagedModule: {} })
+            {
+                _setManagedModules.Add(module.ModuleFile.ModuleFileIndex);
             }
         }
     }
@@ -762,7 +815,7 @@ public sealed class EtwConverterToFirefox : IDisposable
                 {
                     category = CategoryJit;
                 }
-                else if (module.ModuleFileIndex == _coreClrModuleIndex)
+                else if (module.ModuleFileIndex == _coreClrModuleIndex || module.ModuleFileIndex == _clrModuleIndex)
                 {
                     category = CategoryClr;
                 }
@@ -770,9 +823,9 @@ public sealed class EtwConverterToFirefox : IDisposable
         }
 
         var methodIndex = _traceLog.CodeAddresses.MethodIndex(codeAddressIndex);
-        var firefoxMethodIndex = ConvertMethod(codeAddressIndex, methodIndex, profileThread);
+        var firefoxMethodIndex = ConvertMethod(codeAddressIndex, methodIndex, module, profileThread);
 
-        if (methodIndex != MethodIndex.Invalid)
+        if (methodIndex != MethodIndex.Invalid && category is CategoryNative or CategoryClr)
         {
             var nameIndex = profileThread.FuncTable.Name[firefoxMethodIndex];
             var fullMethodName = profileThread.StringArray[nameIndex];
@@ -818,7 +871,7 @@ public sealed class EtwConverterToFirefox : IDisposable
     /// <param name="methodIndex">The method index. Can be invalid.</param>
     /// <param name="profileThread">The current Firefox thread.</param>
     /// <returns>The converted Firefox method index.</returns>
-    private int ConvertMethod(CodeAddressIndex codeAddressIndex, MethodIndex methodIndex, FirefoxProfiler.Thread profileThread)
+    private int ConvertMethod(CodeAddressIndex codeAddressIndex, MethodIndex methodIndex, TraceModuleFile? traceModuleFile, FirefoxProfiler.Thread profileThread)
     {
         var funcTable = profileThread.FuncTable;
         int firefoxMethodIndex;
@@ -849,12 +902,30 @@ public sealed class EtwConverterToFirefox : IDisposable
         //public List<int?> LineNumber { get; }
         //public List<int?> ColumnNumber { get; }
 
+        string? moduleName = null;
+        if (traceModuleFile is {} && _mapModuleFileIndexToFirefox.TryGetValue(traceModuleFile.ModuleFileIndex, out var firefoxModuleIndex))
+        {
+            funcTable.Resource.Add(profileThread.ResourceTable.Length);
+
+            moduleName = Path.GetFileName(traceModuleFile.FilePath);
+            profileThread.ResourceTable.Name.Add(GetOrCreateString(moduleName, profileThread));
+            profileThread.ResourceTable.Lib.Add(firefoxModuleIndex);
+            profileThread.ResourceTable.Length++;
+        }
+        else
+        {
+            funcTable.Resource.Add(-1);
+        }
+
         if (methodIndex == MethodIndex.Invalid)
         {
-            funcTable.Name.Add(GetOrCreateString($"0x{_traceLog.CodeAddresses.Address(codeAddressIndex):X16}", profileThread));
+            var name = moduleName is {}
+                ? $"({moduleName}) 0x{_traceLog.CodeAddresses.Address(codeAddressIndex):X16}"
+                : $"0x{_traceLog.CodeAddresses.Address(codeAddressIndex):X16}";
+
+            funcTable.Name.Add(GetOrCreateString(name, profileThread));
             funcTable.IsJS.Add(false);
             funcTable.RelevantForJS.Add(false);
-            funcTable.Resource.Add(-1);
             funcTable.FileName.Add(null);
             funcTable.LineNumber.Add(null);
             funcTable.ColumnNumber.Add(null);
@@ -870,21 +941,6 @@ public sealed class EtwConverterToFirefox : IDisposable
             funcTable.FileName.Add(null); // TODO
             funcTable.LineNumber.Add(null);
             funcTable.ColumnNumber.Add(null);
-
-            var moduleIndex = _traceLog.CodeAddresses.ModuleFileIndex(codeAddressIndex);
-            if (moduleIndex != ModuleFileIndex.Invalid && _mapModuleFileIndexToFirefox.TryGetValue(moduleIndex, out var firefoxModuleIndex))
-            {
-                funcTable.Resource.Add(profileThread.ResourceTable.Length);
-
-                var moduleName = Path.GetFileName(_traceLog.ModuleFiles[moduleIndex].FilePath);
-                profileThread.ResourceTable.Name.Add(GetOrCreateString(moduleName, profileThread));
-                profileThread.ResourceTable.Lib.Add(firefoxModuleIndex);
-                profileThread.ResourceTable.Length++;
-            }
-            else
-            {
-                funcTable.Resource.Add(-1);
-            }
         }
 
         funcTable.Length++;
@@ -1018,6 +1074,8 @@ public sealed class EtwConverterToFirefox : IDisposable
                     GCAllocationTickEvent.Schema(),
                     GCSuspendExecutionEngineEvent.Schema(),
                     GCRestartExecutionEngineEvent.Schema(),
+                    ContentionEvent.Schema(),
+                    FinalizeObjectEvent.Schema()
                 }
             }
         };

--- a/src/Ultra.Core/EtwUltraProfilerOptions.cs
+++ b/src/Ultra.Core/EtwUltraProfilerOptions.cs
@@ -178,6 +178,13 @@ public class EtwUltraProfilerOptions
             symbolPath.Add(symbolPathText);
         }
 
+        // common to have perfview symbols in a "symbols" directory adjacent to an etl file
+        var dirInfo = new DirectoryInfo(Path.Combine(Environment.CurrentDirectory, "symbols"));
+        if (dirInfo.Exists)
+        {
+            symbolPath.Add(dirInfo.FullName);
+        }
+
         return symbolPath.InsureHasCache(symbolPath.DefaultSymbolCache()).CacheFirst();
     }
 }

--- a/src/Ultra.Core/FirefoxProfiler.cs
+++ b/src/Ultra.Core/FirefoxProfiler.cs
@@ -40,7 +40,7 @@ public static partial class FirefoxProfiler
     public partial class JsonProfilerContext : JsonSerializerContext
     {
     }
-    
+
     public class StackTable
     {
         public StackTable()
@@ -276,13 +276,13 @@ public static partial class FirefoxProfiler
             DebugPath = string.Empty;
             BreakpadId = string.Empty;
         }
-        
+
         public ulong? AddressStart { get; set; }
 
         public ulong? AddressEnd { get; set; }
 
         public ulong? AddressOffset { get; set; }
-        
+
         public string Arch { get; set; }
 
         public string Name { get; set; }
@@ -1032,7 +1032,7 @@ public static partial class FirefoxProfiler
             }
         }
     }
-    
+
 
     public class MarkerTableFormatType : MarkerFormatType
     {

--- a/src/Ultra.Core/Markers/ContentionEvent.cs
+++ b/src/Ultra.Core/Markers/ContentionEvent.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Ultra.Core.Markers;
+
+/// <summary>
+/// Represents a garbage collection allocation tick event marker payload for Firefox Profiler.
+/// </summary>
+public class ContentionEvent : FirefoxProfiler.MarkerPayload
+{
+    /// <summary>
+    /// The type identifier for the Contention event.
+    /// </summary>
+    public const string TypeId = "Contention"; // dotnet.gc.allocation_tick
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GCAllocationTickEvent"/> class.
+    /// </summary>
+    public ContentionEvent()
+    {
+        Type = TypeId;
+    }
+
+    /// <summary>
+    /// Gets or sets the owner of the lock object in bytes.
+    /// </summary>
+    public long OwningThreadId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the duration of the contention event in milliseconds.
+    /// </summary>
+    public double Duration { get; set; }
+
+    /// <inheritdoc />
+    protected internal override void WriteJson(Utf8JsonWriter writer, FirefoxProfiler.MarkerPayload payload, JsonSerializerOptions options)
+    {
+        writer.WriteNumber("owningThreadId", OwningThreadId);
+        writer.WriteNumber("duration", Duration);
+    }
+
+    /// <summary>
+    /// Gets the schema for the Contention event.
+    /// </summary>
+    /// <returns>The marker schema.</returns>
+    public static FirefoxProfiler.MarkerSchema Schema()
+        => new()
+        {
+            Name = TypeId,
+            ChartLabel = "Contention: {marker.data.owningThreadId}",
+            TableLabel = "Contention: {marker.data.owningThreadId}",
+            Display =
+            {
+                            FirefoxProfiler.MarkerDisplayLocation.TimelineOverview,
+                            FirefoxProfiler.MarkerDisplayLocation.MarkerChart,
+                            FirefoxProfiler.MarkerDisplayLocation.MarkerTable
+            },
+            Graphs =        [ ],
+            Data =
+            {
+                            new FirefoxProfiler.MarkerDataItem()
+                            {
+                                Format = FirefoxProfiler.MarkerFormatType.Integer,
+                                Key = "owningThreadId",
+                                Label = "Owning thread Id",
+                            },
+                            new FirefoxProfiler.MarkerDataItem()
+                            {
+                                Format = FirefoxProfiler.MarkerFormatType.String,
+                                Key = "duration",
+                                Label = "Duration",
+                            }
+            }
+        };
+}

--- a/src/Ultra.Core/Markers/FinalizeObjectEvent.cs
+++ b/src/Ultra.Core/Markers/FinalizeObjectEvent.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Ultra.Core.Markers;
+
+/// <summary>
+/// Represents a garbage collection allocation tick event marker payload for Firefox Profiler.
+/// </summary>
+public class FinalizeObjectEvent : FirefoxProfiler.MarkerPayload
+{
+    /// <summary>
+    /// The type identifier for the Contention event.
+    /// </summary>
+    public const string TypeId = "FinalizeObject"; // dotnet.gc.allocation_tick
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GCAllocationTickEvent"/> class.
+    /// </summary>
+    public FinalizeObjectEvent()
+    {
+        Type = TypeId;
+    }
+
+    /// <summary>
+    /// Gets or sets the owner of the lock object in bytes.
+    /// </summary>
+    public required string TypeName { get; set; }
+
+    /// <inheritdoc />
+    protected internal override void WriteJson(Utf8JsonWriter writer, FirefoxProfiler.MarkerPayload payload, JsonSerializerOptions options)
+    {
+        writer.WriteString("typeName", TypeName);
+    }
+
+    /// <summary>
+    /// Gets the schema for the Contention event.
+    /// </summary>
+    /// <returns>The marker schema.</returns>
+    public static FirefoxProfiler.MarkerSchema Schema()
+        => new()
+        {
+            Name = TypeId,
+            ChartLabel = "Finalize: {marker.data.typeName}",
+            TableLabel = "Finalize: {marker.data.typeName}",
+            Display =
+            {
+                            FirefoxProfiler.MarkerDisplayLocation.TimelineOverview,
+                            FirefoxProfiler.MarkerDisplayLocation.MarkerChart,
+                            FirefoxProfiler.MarkerDisplayLocation.MarkerTable
+            },
+            Graphs =        [ ],
+            Data =
+            {
+                            new FirefoxProfiler.MarkerDataItem()
+                            {
+                                Format = FirefoxProfiler.MarkerFormatType.String,
+                                Key = "typeName",
+                                Label = "TypeName",
+                            }
+            }
+        };
+}


### PR DESCRIPTION
This is a small addition to look for relevant processes in a etw trace file. My main usecase is converting etw profiles created by perfview using ultra and I find this feature useful when looking for a process id